### PR TITLE
`modeset()` rewritten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,52 +1,9 @@
-# Prerequisites
-*.d
-
-# Object files
-*.o
-*.ko
-*.obj
-*.elf
-
-# Linker output
-*.ilk
-*.map
-*.exp
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Libraries
-*.lib
-*.a
-*.la
-*.lo
-
-# Shared objects (inc. Windows DLLs)
-*.dll
-*.so
-*.so.*
-*.dylib
-
-# Executables
-*.exe
+*.core
 *.out
-*.app
-*.i*86
-*.x86_64
-*.hex
-
-# Debug files
-*.dSYM/
-*.su
-*.idb
-*.pdb
-
-# Kernel Module Compile Results
-*.mod*
-*.cmd
-.tmp_versions/
-modules.order
-Module.symvers
-Mkfile.old
-dkms.conf
+*.o
+chmod
+mkdir
+rmdir
+cat
+head
+pwd

--- a/chmod.c
+++ b/chmod.c
@@ -28,6 +28,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -47,7 +48,7 @@ static mode_t mode;
 static void recurse(const char *path);
 
 static int
-ftwcallback(const char *name, const struct stat *object, int flag)
+ftwcb(const char *name, const struct stat *object, int flag)
 {
         if (chmod(name, mode) != 0) {
                 fprintf(stderr, "chmod: %s\n", strerror(errno));
@@ -67,7 +68,7 @@ recurse(const char *path)
 {
         int r;
         
-        r = ftw(path, ftwcallback, 1);
+        r = ftw(path, ftwcb, 1);
 
         if (r != 0) {
                 fprintf(stderr, "chmod: %s\n", strerror(errno));
@@ -86,7 +87,6 @@ main(int argc, char *argv[])
 {
         bool R;
         char *m;
-        void *set;
         int i;
         struct stat *s;
         
@@ -116,11 +116,6 @@ main(int argc, char *argv[])
 
         m = argv[0];
 
-        if ((set = modecomp(m)) == NULL) {
-                fprintf(stderr, "chmod: invalid file mode: %s\n", m);
-                return EXIT_FAILURE;
-        }
-
         argc--;
         argv++;
 
@@ -128,7 +123,10 @@ main(int argc, char *argv[])
                 stat(argv[i], s);
                 mode = s->st_mode;
 
-                mode = modeset(set, mode);
+                if ((modeset(m, &mode)) != 0) {
+                        fprintf(stderr, "chmod: invalid file mode: %s\n", m);
+                        return EXIT_FAILURE;
+                }
 
                 if (R) { // -R 
                         recurse(argv[i]);

--- a/mkdir.c
+++ b/mkdir.c
@@ -28,6 +28,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -140,11 +141,9 @@ main(int argc, char *argv[])
                 mode = S_IRWXU | S_IRWXG | S_IRWXO;
                 
                 if (m != NULL) {
-                        if ((set = modecomp(m)) == NULL)
+                        if (modeset(m, &mode) != 0)
                                 fprintf(stderr, "mkdir: invalid file mode: %s",
                                                 m);
-
-                        mode = modeset(set, mode);
                 }
 
                 if (mkdir(argv[i], mode) == -1) {

--- a/util.c
+++ b/util.c
@@ -101,18 +101,19 @@ clause:
         for (; *ptr != '\0'; ptr++) {
                 switch (*ptr) {
                 case 'u':
-                        who |= S_IRWXU | S_ISUID;
+                        who |= S_IRWXU;
                         continue;
                 case 'g':
-                        who |= S_IRWXG | S_ISGID;
+                        who |= S_IRWXG;
                         continue;
                 case 'o':
                         who |= S_IRWXO;
                         continue;
                 case 'a':
-                        who |= S_IRWXU | S_IRWXG | S_IRWXO | S_ISUID | S_ISGID;
+                        who |= S_IRWXU | S_IRWXG | S_IRWXO;
                         continue;
                 default:
+                        who |= S_IRWXU | S_IRWXG | S_IRWXO;
                         break;
                 }
 
@@ -133,7 +134,7 @@ clause:
 
         ptr++;
 
-        /* find permissions, setup mask with who */
+        /* find permissions/permcopy and setup mask to be used */
         for (; *ptr != '\0'; ptr++) {
                 switch (*ptr) {
                 case 'r':
@@ -144,6 +145,15 @@ clause:
                         continue;
                 case 'x':
                         work = who & (S_IXUSR | S_IXGRP | S_IXOTH);
+                        continue;
+                /* TODO
+                case 'X':
+                        continue;
+                case 's':
+                        continue;
+                */
+                case 't':
+                        work |= S_ISVTX;
                         continue;
                 /* permcopy */
                 case 'u':

--- a/util.c
+++ b/util.c
@@ -88,14 +88,14 @@ modeset(const char *modestr, mode_t *modeset)
 {
         const char *ptr;
         char op, perm;
-        mode_t work, who, mode;
+        mode_t copy, work, who, mode;
 
         ptr = modestr;
         mode = *modeset;
 
 clause:
         op = perm = 0;
-        work = who = 0;
+        copy = work = who = 0;
 
         /* Find who's permissions we're editing */
         for (; *ptr != '\0'; ptr++) {
@@ -145,6 +145,25 @@ clause:
                 case 'x':
                         work = who & (S_IXUSR | S_IXGRP | S_IXOTH);
                         continue;
+                /* permcopy */
+                case 'u':
+                        copy = *modeset;
+                        copy |= copy >> 3;
+                        copy |= copy >> 3;
+                        work = who & copy;
+                        break;
+                case 'g':
+                        copy = *modeset;
+                        copy |= copy << 3;
+                        copy |= copy >> 3;
+                        work = who & copy;
+                        break;
+                case 'o':
+                        copy = *modeset;
+                        copy |= copy << 3;
+                        copy |= copy << 3;
+                        work = who & copy;
+                        break;
                 default:
                         break;
                 }

--- a/util.c
+++ b/util.c
@@ -80,7 +80,8 @@
  */
 
 /*
- * 
+ * Accepts symbolic mode string `modestr` and applies its changes to `modeset`
+ * Returns > 0 for syntax error and sets errno=EINVAL
  */
 int
 modeset(const char *modestr, mode_t *modeset)
@@ -89,7 +90,7 @@ modeset(const char *modestr, mode_t *modeset)
         char op, perm;
         mode_t work, who, mode;
 
-        ptr = *modestr;
+        ptr = modestr;
         mode = *modeset;
 
 clause:
@@ -168,8 +169,11 @@ clause:
                 mode &= work;
                 break;
         case '=':
-                /* = operator: clear and then set everything mentioned */
+                /* = operator: clear user permissions mentioned, then set */
+                who = ~who;
+                mode &= who;
 
+                mode |= work;
                 break;
         }
 

--- a/util.h
+++ b/util.h
@@ -2,7 +2,6 @@
 #define _UTIL_H_
 #include <sys/stat.h>
 
-mode_t  modeset(const void *set, mode_t mode);
-void *  modecomp(const char *str);
+int     modeset(const char *modestr, mode_t *modeset);
 
 #endif /* _UTIL_H_ */


### PR DESCRIPTION
`modeset()` is rewritten and is now significantly more lean & clean, and implements the major lacking feature of permcopy syntax.